### PR TITLE
Stop using deprecated aliases for nix settings

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -28,8 +28,8 @@ in
   config =
     if options.nix ? settings then
       {
-        nix.settings.binary-caches = urls;
-        nix.settings.binary-cache-public-keys = keys;
+        nix.settings.substituters = urls;
+        nix.settings.trusted-public-keys = keys;
       }
     else
       {


### PR DESCRIPTION
The settings "binary-caches" and "binary-cache-public-keys" were deprecated with the release of nix 2.0 more than 4 years ago: https://github.com/NixOS/nix/blob/7c90552879da4d1df99b50c85e94201981e60123/doc/manual/src/release-notes/rl-2.0.md

Also some time ago they seem to have stopped working. When i print my config using `nix show-config` with nix 2.11.0,  they don't show up and they don't have any effect any more.