### PR TITLE
home-manager: configure caches via `nix.settings`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,6 @@ Example configuration:
 
 ### Home-manager module
 
-#### Warning
-Home-manager does not contain a mechanism for declaratively adding caches like the system config does.
-This module implements that mechanism itself by generating a `.config/nix/nix.conf` file declaratively.
-
-This has two important implications:
-  1. If you already have entries in that file aside from the default nix cache, you need to move those to `home.file.nixConf.text` so they get included in the generated file.
-  2. If the file is somehow malformed, it will break home-manager itself, so you then have to manually delete it and fix your config. I haven't had any issues myself, but caveat emptor.
-
 #### Usage
 
 Import `home-manager.nix` into your home-manager configuration.

--- a/home-manager-experimental.nix
+++ b/home-manager-experimental.nix
@@ -6,12 +6,14 @@ let
   caches =
     let toCachix = import ./fetchCachix.nix;
     in map toCachix cfg.cachix ++ cfg.extraCaches;
+
   substituters = concatStringsSep " " (map (v: v.url) caches);
   publicKeys = concatStringsSep " " (concatMap (v: v.keys or [ v.key ]) caches);
-  nixConfSource = ''
-    extra-substituters = ${substituters}
-    extra-trusted-public-keys = ${publicKeys}
-  '';
+
+  nixSettings = {
+    extra-substituters = substituters;
+    extra-trusted-public-keys = publicKey;
+  };
 
 in
 {
@@ -53,11 +55,7 @@ in
       default = [ ];
       type = with types; listOf (either string attrs);
     };
-
   };
 
-  config.home.file.nixConf = {
-    target = ".config/nix/nix.conf";
-    text = nixConfSource;
-  };
+  config.nix.settings = nixSettings;
 }

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -12,10 +12,11 @@ let
 
   substituters = concatStringsSep " " (map (v: v.url) cfg.caches);
   publicKeys = concatStringsSep " " (concatMap (v: v.keys or [ v.key ]) cfg.caches);
-  nixConfSource = ''
-    substituters = ${substituters}
-    trusted-public-keys = ${publicKeys}
-  '';
+
+  nixSettings = {
+    inherit substituters;
+    trusted-public-keys = publicKeys;
+  };
 
 in
 {
@@ -81,8 +82,5 @@ in
 
   };
 
-  config.home.file.nixConf = {
-    target = ".config/nix/nix.conf";
-    text = nixConfSource;
-  };
+  config.nix.settings = nixSettings;
 }


### PR DESCRIPTION
`nix.settings` and `home.file.*` (managing `nix.conf`) conflict if used simultaneously:

    Failed assertions:
       - Conflicting managed target files: .config/nix/nix.conf

I find the `nix.settings` interface cleaner and preferable for conflict-resolution, so this change moves declarative-cachix to use it to manage its cache settings.